### PR TITLE
content: replace studio by ide

### DIFF
--- a/pages/ECOSYSTEM.md
+++ b/pages/ECOSYSTEM.md
@@ -4,7 +4,7 @@
 
 For the best onboarding experience, head over to [Gno.land Space](https://www.gnoland.space/) open ecosystem. Here you can set up your Gno wallet, explore existing community-written Gno smart contracts (realms), and become part of our vibrant community by joining [Gno.land Discord](https://discord.com/invite/x76qK4ttHC).
 
-## Gno Studio (IDE)
+## Gno IDE
 
 Gno IDE is a web-based application helping builders quickly spin up Gno realms and packages right on their browsers. Offering a smooth and intuitive UX for building on Gno, you’ll find multiple modes for customizability with all the features you’d expect from an IDE, such as auto compilation in the editor, debugging, and extensive testing capability.
 


### PR DESCRIPTION
Related to https://github.com/gnolang/gno/pull/983, this PR aims to replace `Gno Studio `by `Gno IDE`
