### PR TITLE
chore: "Install" links to the Github version of the Boards realm tutorial

### DIFF
--- a/pages/HOME.md
+++ b/pages/HOME.md
@@ -69,7 +69,7 @@ Are you a builder, tinkerer, or researcher? If you’re looking to create awesom
 ### Explore the universe
 
 - [Discover demo packages](https://github.com/gnolang/gno/tree/master/examples)
-- [Install Gno Key instructions](/r/demo/boards:testboard/5)
+- [Install Gno Key instructions](https://github.com/gnolang/gno/blob/master/examples/gno.land/r/demo/boards/README.md)
 - [Testnets 3](https://test3.gno.land/)
 - [Testnets 2](https://test2.gno.land/)
 - [Explorer links(soon)](#)


### PR DESCRIPTION
We already merged PR https://github.com/gnolang/gno/pull/1049 for the READMEs in the gno repo. This pull request does the same for this HOME page which uses an outdated version of the Board Realm tutorial in the "Install" link. Now, we use the Github tutorial instead of the one on the testnet chain.

(We also already merged a similar PR https://github.com/gnolang/awesome-gno/pull/45 .)